### PR TITLE
Modules upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
+    "@types/react-dom": "^17.0.11",
+    "@types/react-router-dom": "^5.3.2",
+    "@types/react-router-redux": "^5.0.20",
     "cross-env": "^5.1.4",
     "prettier": "2.4.1",
     "react-scripts": "4.0.3"
@@ -11,9 +14,9 @@
     "history": "^4.6.3",
     "marked": "^0.3.6",
     "prop-types": "^15.5.10",
-    "react": "^16.3.0",
+    "react": "^16.8.3",
     "react-dom": "^16.3.0",
-    "react-redux": "^5.0.7",
+    "react-redux": "^7.1.0",
     "react-router": "^4.1.2",
     "react-router-dom": "^4.1.2",
     "react-router-redux": "^5.0.0-alpha.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "cross-env": "^5.1.4",
     "prettier": "2.4.1",
-    "react-scripts": "1.1.1"
+    "react-scripts": "4.0.3"
   },
   "dependencies": {
     "history": "^4.6.3",
@@ -26,8 +26,20 @@
   "scripts": {
     "start": "cross-env PORT=4100 react-scripts start",
     "build": "react-scripts build",
-    "lint-check" : "npx prettier -c './**/*.[tj]s*'",
+    "lint-check": "npx prettier -c './**/*.[tj]s*'",
     "test": "cross-env PORT=4100 react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import React from 'react';
-import { store, history} from './store';
+import { store, history } from './store';
 
 import { Route, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
@@ -10,7 +10,7 @@ import App from './components/App';
 
 ReactDOM.render((
   <Provider store={store}>
-    <ConnectedRouter history={history}>
+    <ConnectedRouter history={history} store={store}>
       <Switch>
         <Route path="/" component={App} />
       </Switch>

--- a/src/store.js
+++ b/src/store.js
@@ -5,9 +5,9 @@ import { promiseMiddleware, localStorageMiddleware } from './middleware';
 import reducer from './reducer';
 
 import { routerMiddleware } from 'react-router-redux'
-import createHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 
-export const history = createHistory();
+export const history = createBrowserHistory();
 
 // Build the middleware for intercepting and dispatching navigation actions
 const myRouterMiddleware = routerMiddleware(history);


### PR DESCRIPTION
Версия react-scripts: 4.0.3.
Версия react: 16.8.3.
Версия react-redux: 7.1.0.

С версией react-scripts 1.1.1 не работают CSS-модули, как ожидалось.
До версии react-redux 7.1.0 не работали useSelector/useDispatch.
react обновился как зависимость от react-redux, но очень аккуратно.

Внимание! Обновление до последних версий вообще ломает все, поэтому обновил по минимуму, "минимальный рабочий вариант".

Поправил  пару файлов, ибо они "заточены" под такие обновления.

Чтобы обновиться, нужно внести изменения в package.json и еще два файла, как тут, удалить package-lock.json и запустить 

`npm install`