### PR TITLE
Error in TagList of Editor when refresh page

### DIFF
--- a/src/components/editor/tag-list.jsx
+++ b/src/components/editor/tag-list.jsx
@@ -1,8 +1,6 @@
 import { useSelector } from 'react-redux';
 import Tag from './tag'
 
-//@TODO должен передаваться массив
-
 const TagList = () => {
     const { tags } = useSelector(store => store.editor);
 

--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -23,7 +23,7 @@ export default (state = initState, action) => {
         tags: action.payload ? action.payload.article.tagList : []
       };
     case EDITOR_PAGE_UNLOADED:
-      return {};
+      return initState;
     case ARTICLE_SUBMITTED:
       return {
         ...state,


### PR DESCRIPTION
Компонент TagList принимал массив. До этого там была проверка на undefined. В редьюсере при выгрузке странице (закрытии страницы) массив состояния удалялся. Теперь состояние возвращается к начальному состоянию которое содержит массив. 